### PR TITLE
Simplify cylinder

### DIFF
--- a/cylinder/DisplayOn.C
+++ b/cylinder/DisplayOn.C
@@ -17,6 +17,7 @@ PHG4Reco * DisplayOn(const char *mac = "cyl.mac")
   Fun4AllServer *se = Fun4AllServer::instance();
   PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
   g4->InitRun(se->topNode());
+  g4->ApplyDisplayAction();
   sprintf(cmd, "/control/execute %s", mac);
   g4->ApplyCommand(cmd);
   return g4;

--- a/cylinder/Fun4All_G4_Cylinder.C
+++ b/cylinder/Fun4All_G4_Cylinder.C
@@ -30,13 +30,11 @@ int Fun4All_G4_Cylinder(const int nEvents = 10, const char * outfile = NULL)
   Fun4AllServer *se = Fun4AllServer::instance();
   se->Verbosity(0);
 
+  recoConsts *rc = recoConsts::instance();
+//  rc->set_IntFlag("RANDOMSEED", 12345); // if you want to use a fixed seed
   // PHG4ParticleGenerator generates particle
   // distributions in eta/phi/mom range
   PHG4ParticleGenerator *gen = new PHG4ParticleGenerator("PGENERATOR");
-  int uniqueseed = TRandom3(0).GetSeed();
-  recoConsts *rc = recoConsts::instance();
-  rc->set_IntFlag("RANDOMSEED", uniqueseed);
-  gen->set_seed(uniqueseed);
   //gen->set_name("gamma");
   gen->set_name("e+");
   gen->set_vtx(0, 0, 0);


### PR DESCRIPTION
This PR removes TRandom from the macro - our event generators now use PHRandomSeed internally, it is not necessary anymore to initialize the seed randomly from the outside.
Display.C now calls PHG4Reco::ApplyDisplayAction() to set the vis attributes for the registered subsystems