### PR TITLE
comment out loading of libsartre for cfns tutorial 

### DIFF
--- a/eventgenerator_display/Fun4All_Generator_Display.C
+++ b/eventgenerator_display/Fun4All_Generator_Display.C
@@ -21,7 +21,7 @@ R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libg4testbench.so)
 R__LOAD_LIBRARY(libPHPythia6.so)
 R__LOAD_LIBRARY(libPHPythia8.so)
-R__LOAD_LIBRARY(libPHSartre.so)
+//R__LOAD_LIBRARY(libPHSartre.so)
 #endif
 
 using namespace std;
@@ -57,7 +57,7 @@ int Fun4All_Generator_Display(
   // Use Pythia 6
   const bool runpythia6 = true;
   // Or:
-  // Use Sartre
+  // Use Sartre - DO NOT USE RIGHT NOW
   const bool runsartre = false;
 
 


### PR DESCRIPTION
This PR is just for the cnfs tutorial. SARTRE_DIR is now set in the sphenix setup script but it hasn't found its way into the VM for that tutorial. So the macro bombs out with a missing SARTRE_DIR env var