### PR TITLE
add method to override initial vertex setting in the SvtxEvaluator

### DIFF
--- a/myjetanalysis/src/MyJetAnalysis.cc
+++ b/myjetanalysis/src/MyJetAnalysis.cc
@@ -143,7 +143,7 @@ int MyJetAnalysis::End(PHCompositeNode* topNode)
 int MyJetAnalysis::InitRun(PHCompositeNode* topNode)
 {
   m_jetEvalStack = shared_ptr<JetEvalStack>(new JetEvalStack(topNode, m_recoJetName, m_truthJetName));
-
+  m_jetEvalStack->get_stvx_eval_stack()->set_use_initial_vertex(initial_vertex);
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/myjetanalysis/src/MyJetAnalysis.h
+++ b/myjetanalysis/src/MyJetAnalysis.h
@@ -39,7 +39,7 @@ class MyJetAnalysis : public SubsysReco
     m_ptRange.first = low;
     m_ptRange.second = high;
   }
-
+  void use_initial_vertex(const bool b = true) {initial_vertex = b;}
   int Init(PHCompositeNode *topNode);
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
@@ -58,6 +58,9 @@ class MyJetAnalysis : public SubsysReco
 
   //! pT range
   std::pair<double, double> m_ptRange;
+
+  //! flag to use initial vertex in track evaluator
+  bool initial_vertex = false;
 
   //! max track-jet matching radius
   double m_trackJetMatchingRadius;


### PR DESCRIPTION
This PR adds the capability to choose the initial vertex. The SvtxEvaluator now defaults to the Acts vertex which does not exist when using EIC tracking. The svtx evaluator gets called by the jet evaluator, so this setting gets funneled through the jetevalstack in the InitRun