### PR TITLE
print values in cm for magfield

### DIFF
--- a/MagneticField/src/FieldMapReadBack.cc
+++ b/MagneticField/src/FieldMapReadBack.cc
@@ -52,7 +52,7 @@ void FieldMapReadBack::PrintField(const double x, const double y, const double z
 
   double Bf[3];
   fieldmap->GetFieldValue(Point, Bf);
-  std::cout << "Point: " << x / cm << "/" << y / cm << "/" << z / cm << std::endl;
+  std::cout << "Point: " << x << "/" << y << "/" << z << " cm" << std::endl;
   std::cout << "BField: " << Bf[0] / tesla << "/" << Bf[1] / tesla << "/" << Bf[2] / tesla << std::endl;
   return;
 }


### PR DESCRIPTION
minor fix for the magnetic field tutorial, it now prints out the coordinates correctly in cm