### PR TITLE
Update to CaloHistGen Tutorial Code

### DIFF
--- a/CaloDataAnaRun24pp/macro/Fun4All_CaloHistGen.C
+++ b/CaloDataAnaRun24pp/macro/Fun4All_CaloHistGen.C
@@ -24,9 +24,10 @@ R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libffarawobjects.so)
 R__LOAD_LIBRARY(libcaloHistGen.so)
 
-  void Fun4All_CaloHistGen(const int nEvents = 1000, const std::string &fnameCalib = "DST_CALO_run2pp_ana437_2024p007-00048089-00000.root", const std::string &fnameRaw = "DST_CALOFITTING_run2pp_ana437_2024p007-00048089-00000.root",const std::string &outName = "commissioning.root", const std::string &dbtag = "ProdA_2024")
+  void Fun4All_CaloHistGen(const int nEvents = 0, const std::string &fnameCalib = "DST_CALO_run2pp_ana462_2024p010_v001-00052032-00004.root", const std::string &fnameRaw = "DST_CALOFITTING_run2pp_ana446_2024p007-00052032-00004.root",const std::string &outName = "commissioning.root", const std::string &dbtag = "ProdA_2024")
 {
   Fun4AllServer *se = Fun4AllServer::instance();
+  se->Verbosity(0);
   recoConsts *rc = recoConsts::instance();
   
   pair<int, int> runseg = Fun4AllUtils::GetRunSegment(fnameCalib);
@@ -61,7 +62,7 @@ R__LOAD_LIBRARY(libcaloHistGen.so)
   calo->doZDC(1, "TOWERINFO_CALIB_ZDC");
 
   // Store GL1 Information?
-  calo->doTrig(1, "GL1Packet");
+  calo->doTrig(0, "GL1Packet");
 
   //reconstruct diphoton pairs?
   calo->setPi0Reco(1);

--- a/CaloDataAnaRun24pp/macro/Fun4All_CaloHistGen.C
+++ b/CaloDataAnaRun24pp/macro/Fun4All_CaloHistGen.C
@@ -24,7 +24,7 @@ R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libffarawobjects.so)
 R__LOAD_LIBRARY(libcaloHistGen.so)
 
-  void Fun4All_CaloHistGen(const int nEvents = 0, const std::string &fnameCalib = "DST_CALO_run2pp_ana462_2024p010_v001-00052032-00004.root", const std::string &fnameRaw = "DST_CALOFITTING_run2pp_ana446_2024p007-00052032-00004.root",const std::string &outName = "commissioning.root", const std::string &dbtag = "ProdA_2024")
+  void Fun4All_CaloHistGen(const int nEvents = 20000, const std::string &fnameCalib = "DST_CALO_run2pp_ana462_2024p010_v001-00052032-00004.root", const std::string &fnameRaw = "DST_CALOFITTING_run2pp_ana446_2024p007-00052032-00004.root",const std::string &outName = "commissioning.root", const std::string &dbtag = "ProdA_2024")
 {
   Fun4AllServer *se = Fun4AllServer::instance();
   se->Verbosity(0);
@@ -48,6 +48,7 @@ R__LOAD_LIBRARY(libcaloHistGen.so)
   se->registerInputManager(inCalib);
 
   Process_Calo_Calib();
+
   
   caloHistGen *calo = new caloHistGen(outName);
   // What subsystems do you want?
@@ -59,7 +60,7 @@ R__LOAD_LIBRARY(libcaloHistGen.so)
   calo->doHCals(1, "TOWERINFO_CALIB_HCALOUT", "TOWERINFO_CALIB_HCALIN");
 
   // Store ZDC information?
-  calo->doZDC(1, "TOWERINFO_CALIB_ZDC");
+  calo->doZDC(1, "TOWERS_ZDC");
 
   // Store GL1 Information?
   calo->doTrig(0, "GL1Packet");

--- a/CaloDataAnaRun24pp/src/caloHistGen.cc
+++ b/CaloDataAnaRun24pp/src/caloHistGen.cc
@@ -155,6 +155,7 @@ int caloHistGen::process_event(PHCompositeNode *topNode)
   unsigned int tower_range = 0;
   if (storeEMCal && emcTowerContainer)
   {
+    std::cout << "Looping over EMCal towers" << std::endl;
     tower_range = emcTowerContainer->size();
     for (unsigned int iter = 0; iter < tower_range; iter++)
     {
@@ -178,6 +179,7 @@ int caloHistGen::process_event(PHCompositeNode *topNode)
 
   if (storeClusters && storeEMCal)
   {
+    std::cout << "Storing clusters" << std::endl;
     RawClusterContainer::ConstRange clusterEnd = clusterContainer->getClusters();
     RawClusterContainer::ConstIterator clusterIter;
     for (clusterIter = clusterEnd.first; clusterIter != clusterEnd.second; clusterIter++)
@@ -207,9 +209,12 @@ int caloHistGen::process_event(PHCompositeNode *topNode)
   // pi0 reconstruction
   if (doPi0Reco && storeEMCal)
   {
+    std::cout << "Reconstructing dicluster pairs" << std::endl;
     RawClusterContainer::ConstRange clusters = clusterContainer->getClusters();
     RawClusterContainer::ConstIterator clusterIter1, clusterIter2;
     int clusterCounter1 = 0;
+    int clusterCounter2 = 0;
+
     for (clusterIter1 = clusters.first; clusterIter1 != clusters.second; clusterIter1++)
     {
       RawCluster *recoCluster1 = clusterIter1->second;
@@ -226,14 +231,13 @@ int caloHistGen::process_event(PHCompositeNode *topNode)
       }
       CLHEP::Hep3Vector E_vec_cluster1 = RawClusterUtility::GetECoreVec(*recoCluster1, hep_vertex);
 
-      int clusterCounter2 = 0;
       for (clusterIter2 = clusters.first; clusterIter2 != clusters.second; clusterIter2++)
       {
+	clusterCounter2++;
         if (clusterCounter2 <= clusterCounter1)
         {
           continue;  // prevents double counting pairs
         }
-        clusterCounter2++;
         RawCluster *recoCluster2 = clusterIter2->second;
         CLHEP::Hep3Vector E_vec_cluster2 = RawClusterUtility::GetECoreVec(*recoCluster2, hep_vertex);
         if (recoCluster2->get_chi2() > 4)
@@ -244,7 +248,7 @@ int caloHistGen::process_event(PHCompositeNode *topNode)
         {
           continue;
         }
-        if (std::abs(E_vec_cluster1.mag() - E_vec_cluster2.mag()) / (E_vec_cluster1.mag() + E_vec_cluster2.mag()) > maxAlpha)
+        if (std::fabs(E_vec_cluster1.mag() - E_vec_cluster2.mag()) / (E_vec_cluster1.mag() + E_vec_cluster2.mag()) > maxAlpha)
         {
           continue;
         }

--- a/CaloDataAnaRun24pp/src/caloHistGen.cc
+++ b/CaloDataAnaRun24pp/src/caloHistGen.cc
@@ -155,7 +155,6 @@ int caloHistGen::process_event(PHCompositeNode *topNode)
   unsigned int tower_range = 0;
   if (storeEMCal && emcTowerContainer)
   {
-    std::cout << "Looping over EMCal towers" << std::endl;
     tower_range = emcTowerContainer->size();
     for (unsigned int iter = 0; iter < tower_range; iter++)
     {
@@ -179,7 +178,6 @@ int caloHistGen::process_event(PHCompositeNode *topNode)
 
   if (storeClusters && storeEMCal)
   {
-    std::cout << "Storing clusters" << std::endl;
     RawClusterContainer::ConstRange clusterEnd = clusterContainer->getClusters();
     RawClusterContainer::ConstIterator clusterIter;
     for (clusterIter = clusterEnd.first; clusterIter != clusterEnd.second; clusterIter++)
@@ -209,7 +207,6 @@ int caloHistGen::process_event(PHCompositeNode *topNode)
   // pi0 reconstruction
   if (doPi0Reco && storeEMCal)
   {
-    std::cout << "Reconstructing dicluster pairs" << std::endl;
     RawClusterContainer::ConstRange clusters = clusterContainer->getClusters();
     RawClusterContainer::ConstIterator clusterIter1, clusterIter2;
     int clusterCounter1 = 0;
@@ -316,7 +313,7 @@ int caloHistGen::process_event(PHCompositeNode *topNode)
   TowerInfoContainer *zdcTowerContainer = findNode::getClass<TowerInfoContainer>(topNode, m_zdcTowerNode.c_str());
   if (!zdcTowerContainer)
   {
-    std::cout << PHWHERE << "caloHistGen::process_event: " << m_emcTowerNode << " node is missing. Output related to this node will be empty" << std::endl;
+    std::cout << PHWHERE << "caloHistGen::process_event: " << m_zdcTowerNode.c_str() << " node is missing. Output related to this node will be empty" << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 


### PR DESCRIPTION
Bug fixes:

- Fixed issue where HEP3Vectors were not getting proper clusters
- Fixed issue where combinatoric redundancy filter was killing all pi0 pairs
- Fixed issue where ZDC node lookup was reporting that the EMCal node was missing
- Updated ZDC node name in Macro
- 