### PR TITLE
Fixed trigger checking bug

### DIFF
--- a/CaloDataAnaRun24pp/src/caloHistGen.cc
+++ b/CaloDataAnaRun24pp/src/caloHistGen.cc
@@ -128,7 +128,7 @@ int caloHistGen::process_event(PHCompositeNode *topNode)
       bool trig_decision = ((triggervec & 0x1U) == 0x1U);
 
       triggervec = (triggervec >> 1U) & 0xffffffffU;
-      if (!trig_decision && i == trigRequired[i])
+      if (!trig_decision && trigRequired[i])
       {
         return 0;
       }


### PR DESCRIPTION
Hi,
I was going through this tutorial and noticed something that I found weird with the trigger handling in `caloHistGen.cc`. 

In short, it seems to me that there is a bug with line [131](https://github.com/sPHENIX-Collaboration/tutorials/blob/10f3ded7c51ea8b7ef04db8406bffdca35498ff1/CaloDataAnaRun24pp/src/caloHistGen.cc#L131) where the code checks if `i == trigRequired[i]` and only skips the event if this is true (and the current bit in `triggervec` is set). This seems like unwanted behavior as `trigRequired` is an `int[]` where each entry is either 0 (if not requiring that trigger bit) or 1 (if requiring the trigger bit), and hence never 2-63, which i will be for the non 0 and 1 index bits.

I believe that the correct logic would be to just check if the trigger bit is required to be set, like I have now changed in this branch. 

If I have made a mistake, please let me know as I am trying to learn more about the sPHENIX software.

Thanks!